### PR TITLE
Improve footer year display

### DIFF
--- a/catalogo.html
+++ b/catalogo.html
@@ -100,7 +100,7 @@
     WhatsApp
   </a>
   <footer>
-    Feito com amor em Portugal – 2025 &nbsp; | &nbsp;
+    Feito com amor em Portugal – <span id="year"></span> &nbsp; | &nbsp;
     <a href="https://instagram.com/teulink" target="_blank">Instagram</a>
   </footer>
   <script>
@@ -254,6 +254,8 @@
     }
     // Inicialização
     renderProdutos('pt');
+    // Atualiza ano automaticamente
+    document.getElementById('year').textContent = new Date().getFullYear();
   </script>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -392,7 +392,7 @@
     WhatsApp
   </a>
   <footer>
-    Feito com amor em Portugal – 2025 &nbsp; | &nbsp;
+    Feito com amor em Portugal – <span id="year"></span> &nbsp; | &nbsp;
     <a href="https://instagram.com/teulink" target="_blank">Instagram</a>
   </footer>
   <script>
@@ -464,6 +464,8 @@
     }
     // Default: Português
     setLang('pt');
+    // Atualiza ano automaticamente
+    document.getElementById('year').textContent = new Date().getFullYear();
     // Fecha menu mobile ao clicar em link (melhora UX)
     document.querySelectorAll('#main-nav a').forEach(a => {
       a.addEventListener('click', () => {


### PR DESCRIPTION
## Summary
- update footer year to use JavaScript
- set current year automatically on both pages

## Testing
- `git status --short`
- `git log -1 --stat`


------
https://chatgpt.com/codex/tasks/task_e_685a53e97e748330a738d93462b0277a